### PR TITLE
Maven war 332

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/templates/maven/pom.xml
+++ b/src/main/resources/templates/maven/pom.xml
@@ -38,7 +38,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>


### PR DESCRIPTION
Upgrade to war plugin 3.3.2 to get MWAR-441 fix.

Not sure the other commit is really helpful at all, for building the starter web app itself (I assume).   Might as well update maybe, or could cut that out of PR.