### PR TITLE
Upgrade liberty-maven-plugin and maven-war-plugin

### DIFF
--- a/src/main/resources/templates/maven/pom.xml
+++ b/src/main/resources/templates/maven/pom.xml
@@ -38,12 +38,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.3.4</version>
+                    <version>3.5.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Related to https://github.com/OpenLiberty/start.openliberty.io/issues/28

Upgrade to the latest `liberty-maven-plugin` and `maven-war-plugin`

https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-war-plugin
https://github.com/OpenLiberty/ci.maven/releases