### PR TITLE
Revert "Update production"

### DIFF
--- a/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
+++ b/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
@@ -101,18 +101,11 @@ public class StarterBuilderImpl implements StarterBuilder {
             properties.put("jakartaEEArtifactId", "javaee-api");
             properties.put("jakartaEEVersion", "7.0.0");
             properties.put("jakartaEEFeature", "javaee-7.0");
-        }
-        else if("8".equals(jakartaEEVersion)) {
+        } else {
             properties.put("jakartaEEGroupId", "jakarta.platform");
             properties.put("jakartaEEArtifactId", "jakarta.jakartaee-api");
             properties.put("jakartaEEVersion", "8.0.0");
             properties.put("jakartaEEFeature", "jakartaee-8.0");
-        } 
-        else {
-            properties.put("jakartaEEGroupId", "jakarta.platform");
-            properties.put("jakartaEEArtifactId", "jakarta.jakartaee-api");
-            properties.put("jakartaEEVersion", "9.1.0");
-            properties.put("jakartaEEFeature", "jakartaee-9.1");
         }
 
         return this;

--- a/src/main/java/io/openliberty/website/starter/metadata/Constants.java
+++ b/src/main/java/io/openliberty/website/starter/metadata/Constants.java
@@ -16,12 +16,11 @@ import javax.json.JsonObject;
 
 public class Constants {
     public static final String[] SUPPORTED_JAVA_VERSIONS = new String[] { "8", "11", "17" };
-    public static final String[] SUPPORTED_JAKARTAEE_VERSIONS = new String[] { "7", "8", "9" };
-    public static final String[] SUPPORTED_MICROPROFILE_VERSIONS = new String[] { "1.4", "2.2", "3.3", "4.1", "5.0" };
+    public static final String[] SUPPORTED_JAKARTAEE_VERSIONS = new String[] { "7", "8" };
+    public static final String[] SUPPORTED_MICROPROFILE_VERSIONS = new String[] { "1.4", "2.2", "3.3", "4.1" };
 
     public static final JsonObject JAKARTA_EE_MICROPROFILE_COMPATIBILITIES = Json.createObjectBuilder()
             .add("7", Json.createObjectBuilder().add("m", Json.createArrayBuilder().add("1.4")))
             .add("8", Json.createObjectBuilder().add("m", Json.createArrayBuilder().add("2.2").add("3.3").add("4.1")))
-            .add("9", Json.createObjectBuilder().add("m", Json.createArrayBuilder().add("5.0")))
             .build();
 }

--- a/src/main/resources/templates/maven/pom.xml
+++ b/src/main/resources/templates/maven/pom.xml
@@ -38,12 +38,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.3.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Reverts OpenLiberty/start.openliberty.io#42

EE9 has new java package names.  The starter needs to make those changes from `javax` to `jakarta`