### PR TITLE
New GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report bugs that were included in a released version of Open Liberty
+title: ''
+labels: "release bug"
+assignees: ''
+
+---
+
+**Describe the bug**  
+A clear and concise description of what the bug is. 
+
+**Steps to Reproduce**  
+Steps to reproduce the bug
+
+**Expected behavior**  
+A clear and concise description of what you expected to happen.
+
+**Diagnostic information:**
+ - Group [e.g. com.demo]
+ - Artifact [e.g. app-name]
+  - Build Tool
+    - [ ] Maven
+    - [ ] Gradle
+ - Java SE Version [e.g. 8, 11, 17]
+ - Java EE/Jakarta EE Version [e.g. None, 8.0, 9.1]
+ - MicroProfile Version [e.g. None, 4.1, 5.0]
+
+**Additional context**  
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,13 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Describe your idea for new feature to add to the Liberty Starter**  
+A clear and concise description of your idea. 
+What new capabilities would the feature enable or what problem would it solve? 
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Describe why the new feature is important**  
+A clear and concise description of the value of and use case for your suggestion. 
+For example, "As a developer/admin/etc. I want to be able to x so that I can y.."
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
+**Any additional context**  
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,0 +1,8 @@
+---
+name: Other issue
+about: None of the other options fit
+title: ''
+labels: ''
+assignees: ''
+
+---


### PR DESCRIPTION
For #34

Use the existing Open Liberty [templates](https://github.com/OpenLiberty/open-liberty/tree/integration/.github/ISSUE_TEMPLATE) as a base template for this repository.