### PR TITLE
Version maintenance in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build with maven to produce the .war application
-FROM icr.io/appcafe/open-liberty-devfile-stack:latest as build
+FROM icr.io/appcafe/open-liberty-devfile-stack:21.0.0.12 as build
 
 USER root
 COPY src /src
@@ -11,7 +11,7 @@ USER 1001
 # Stage 2: Place application on a liberty server
 # TODO: Invest in using a kernel build and use the feature manager to install 
 # needed Liberty features
-FROM icr.io/appcafe/open-liberty:21.0.0.12-full-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:22.0.0.1-full-java8-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT


### PR DESCRIPTION
- Pin `open-liberty-devfile-stack` to a version to satisfy a Dockerfile
linter.

- Upgrade to the latest liberty version 22.0.0.1