### PR TITLE
automate PR checker for prohibited terms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test application 
+
+on:
+  pull_request:
+    branches: [prod, staging]
+
+jobs:
+  check-files:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    outputs:
+      canSkip: ${{ steps.Checker.outputs.canSkip }}
+    steps:
+      - name: Get files
+        uses: actions/checkout@v2
+      - name: Get tools
+        uses: actions/checkout@v2
+        with:
+          path: tools/
+          repository: openliberty/guides-common
+      - id: Checker
+        shell: bash
+        run: bash ./tools/pr-checker/checker.sh ${{ github.repository }} ${{ github.event.pull_request.number }} | tee checker.log
+      - name: Summary
+        if: always()
+        run: |
+          cat ./checker.log |  tail -n +2;
+          echo "====== Examine logs in Checker ======"
+          if [ '${{ steps.Checker.outcome }}' != 'success' ]; then exit 1; fi


### PR DESCRIPTION
Define a github action in .github/workflows/test.yml. The action will be run for any PR change that will trigger the checker to check the license year and prohibited words.

The source of the checker is located at https://github.com/OpenLiberty/guides-common/tree/prod/pr-checker. The checker is a [python script](https://github.com/OpenLiberty/guides-common/blob/prod/pr-checker/checker.py).

The [deny_list.json](https://github.com/OpenLiberty/guides-common/blob/prod/pr-checker/deny_list.json) defines the prohibited words and the [warning_list.json](https://github.com/OpenLiberty/guides-common/blob/prod/pr-checker/warning_list.json) defines the warning words.