### PR TITLE
Whitespace fixes; comment consistency

### DIFF
--- a/src/main/resources/templates/server/server.xml
+++ b/src/main/resources/templates/server/server.xml
@@ -13,15 +13,17 @@
         encoded password using bin/securityUtility encode and add it below in the password attribute of the keyStore element. 
         Then uncomment the keyStore element. -->
     <!--
-     <keyStore password=""/> 
+    <keyStore password=""/> 
     -->
 
     <!--For a user registry configuration, configure your user registry. For example, configure a basic user registry using the
-        basicRegistry element. Specify your own user name below in the name attribute of the user element. For the password, 
-        generate an encoded password using bin/securityUtility encode and add it in the password attribute of the user element. 
+        basicRegistry element. Specify your own user name below in the name attribute of the user element. For the password,
+        generate an encoded password using bin/securityUtility encode and add it in the password attribute of the user element.
         Then uncomment the user element. -->
-    <basicRegistry id="basic" realm="BasicRealm"> 
-         <!-- <user name="yourUserName" password="" />  --> 
+    <basicRegistry id="basic" realm="BasicRealm">
+        <!--
+        <user name="yourUserName" password="" />
+        -->
     </basicRegistry>
 
     <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->


### PR DESCRIPTION
- Straighten out the tabbing and end of line whitespaces

- Make it easier for non IDE editors to uncomment the `<user>` element
and make it consistent with how we comment the `<keyStore>` element.