### PR TITLE
remove generate list files in template Readme.txt

### DIFF
--- a/src/main/resources/templates/readme/README.txt
+++ b/src/main/resources/templates/readme/README.txt
@@ -15,28 +15,9 @@ will make it easier to create your application image on top of the Open Liberty 
    start the default server. When complete, you will see the necessary features installed and the message 
    "server is ready to run a smarter planet."
 
-  A starter project using Maven is generated for you with the following files:
-  * mvnw
-  * mvnw.cmd
-  * pom.xml
-  * src/main/java/com/demo/rest/RestApplication.java
-  * src/main/liberty/config/server.xml
-  * Dockerfile
-  * .dockerignore
-
 3) If you selected Gradle as your build tool, then open a command line session, navigate to the installation 
    directory, and run `gradlew libertyStart` to start the default server. When complete, you will see the 
    necessary features installed from the installFeature task and the message "server is ready to run a smarter planet."
-
-  A starter project using Gradle is generated for you with the following files:
-  * build.gradle
-  * gradlew.bat
-  * gradlew
-  * settings.gradle
-  * src/main/java/com/demo/rest/RestApplication.java
-  * src/main/liberty/config/server.xml
-  * Dockerfile
-  * .dockerignore
 
 For information on developing your application in dev mode using either Maven or Gradle, see the dev mode documentation 
 (https://openliberty.io/docs/latest/development-mode.html).

--- a/src/main/resources/templates/readme/README.txt
+++ b/src/main/resources/templates/readme/README.txt
@@ -10,14 +10,17 @@ If you plan on developing and/or deploying your app in a containerized environme
 will make it easier to create your application image on top of the Open Liberty Docker image.
 
 1) Once you download the starter project, unpackage the .zip file on your machine.
+<#if buildType == "maven">
 2) If you selected Maven as your build tool, then open a command line session, navigate to the 
    installation directory, and run `mvnw liberty:run`. This will install all required dependencies and 
    start the default server. When complete, you will see the necessary features installed and the message 
    "server is ready to run a smarter planet."
-
-3) If you selected Gradle as your build tool, then open a command line session, navigate to the installation 
+</#if>
+<#if buildType == "gradle">
+2) If you selected Gradle as your build tool, then open a command line session, navigate to the installation
    directory, and run `gradlew libertyStart` to start the default server. When complete, you will see the 
    necessary features installed from the installFeature task and the message "server is ready to run a smarter planet."
+</#if>
 
 For information on developing your application in dev mode using either Maven or Gradle, see the dev mode documentation 
 (https://openliberty.io/docs/latest/development-mode.html).

--- a/src/main/resources/templates/templates.json
+++ b/src/main/resources/templates/templates.json
@@ -89,7 +89,8 @@
 	"readme": [
 		{
 			"template": "readme/README.txt",
-			"fileName": "README.txt"
+			"fileName": "README.txt",
+			"process": true
 		}
 	]
 }


### PR DESCRIPTION
1. Remove the list of all of the generated files.
2. The readme should contain the corresponding instructions for the maven/gradle info. Use the Java templating library to conditionally add step 2) or step 3) based on the user's build tool input choice (i.e. Maven or Gradle)


Test locally

README.txt generated when select maven
![image](https://user-images.githubusercontent.com/30509453/159930346-7a6b4183-261f-41aa-b05a-5c5bd9968f44.png)

README.txt generated when select gradle
![image](https://user-images.githubusercontent.com/30509453/159930484-661607b7-55c0-4091-8f18-4e8fced8ac1b.png)
