### PR TITLE
PR82 upgrade mvnw to 3.8.5 and gradle to 6.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.6.3</version>
+            <version>3.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>

--- a/src/main/resources/templates/gradle/gradle-wrapper.properties
+++ b/src/main/resources/templates/gradle/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/templates/maven/maven-wrapper.properties
+++ b/src/main/resources/templates/maven/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar


### PR DESCRIPTION
upgrade maven to 3.8.5
upgrade gradle to 6.9.2

Run mvn liberty:dev in starter.openliberty.io
Visit https://localhost:9443/api/start/info to confirm the API is healthy
Downloads the app-name.zip generated using maven/gradle for jdk8, 11, 17
test individual .zip files by running ./gradlew libertyDev or ./mvnw liberty:dev to make sure they successfully build/defaultServer started
