### PR TITLE
Update dockerignore

### DIFF
--- a/src/main/resources/templates/docker/dockerignore
+++ b/src/main/resources/templates/docker/dockerignore
@@ -1,3 +1,3 @@
 ${buildPath}
 !${buildPath}*.war
-!/target/liberty/wlp/usr/shared/resources/*
+!${buildPath}liberty/wlp/usr/shared/resources/*

--- a/src/main/resources/templates/docker/dockerignore
+++ b/src/main/resources/templates/docker/dockerignore
@@ -1,2 +1,3 @@
 ${buildPath}
 !${buildPath}*.war
+!/target/liberty/wlp/usr/shared/resources/*


### PR DESCRIPTION
Allow users to copy libraries under the `/target/liberty/wlp/usr/shared/resources` directory when build docker image