### PR TITLE
CORS: Add new openliberty.io staging sites

### DIFF
--- a/server.xml
+++ b/server.xml
@@ -30,7 +30,7 @@
 
     <cors
 		domain="/api/start"
-		allowedOrigins="https://www.openliberty.io,https://openliberty.io,https://draft-openlibertyio.mybluemix.net,https://staging-openlibertyio.mybluemix.net,https://ui-draft-openlibertyio.mybluemix.net,https://draft-ui-openlibertyio.mybluemix.net,https://ui-staging-openlibertyio.mybluemix.net,https://staging-ui-openlibertyio.mybluemix.net,https://demo1-openlibertyio.mybluemix.net,https://demo2-openlibertyio.mybluemix.net,https://us-south.openliberty.io,https://us-east.openliberty.io,https://eu-gb.openliberty.io,https://eu-de.openliberty.io,https://au-syd.openliberty.io"
+		allowedOrigins="https://www.openliberty.io,https://openliberty.io,https://draft-openlibertyio.mybluemix.net,https://staging-openlibertyio.mybluemix.net,https://ui-draft-openlibertyio.mybluemix.net,https://draft-ui-openlibertyio.mybluemix.net,https://ui-staging-openlibertyio.mybluemix.net,https://staging-ui-openlibertyio.mybluemix.net,https://demo1-openlibertyio.mybluemix.net,https://demo2-openlibertyio.mybluemix.net,https://us-south.openliberty.io,https://us-east.openliberty.io,https://eu-gb.openliberty.io,https://eu-de.openliberty.io,https://au-syd.openliberty.io,https://ui-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud,https://staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud"
 		allowedHeaders="Accept, Accept-Encoding, Content-Type, X-Requested-With" 
 		allowedMethods="GET,POST"
 		exposeHeaders=""


### PR DESCRIPTION
Allow for the new openliberty.io staging sites environments to call the new staging Open Liberty Starter environment

# Error to be fixed
`Access to XMLHttpRequest at 'https://starter-staging.rh9j6zz75er.us-east.codeengine.appdomain.cloud/api/start/info' from origin 'https://ui-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

# New openliberty.io staging sites
https://ui-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/start/
https://staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/

# New OL Starter site
https://ui-staging-openlibertyio.mqj6zf7jocq.us-south.codeengine.appdomain.cloud/