### PR TITLE
add dependencies to fix gradle/maven build failed

### DIFF
--- a/src/main/resources/templates/gradle/build.gradle
+++ b/src/main/resources/templates/gradle/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     // provided dependencies
     <#if jakartaEEVersion != "None">providedCompile '${jakartaEEGroupId}:${jakartaEEArtifactId}:${jakartaEEVersion}' </#if>
     <#if microProfileVersion != "None">providedCompile 'org.eclipse.microprofile:microprofile:${microProfileVersion}' </#if>
-
+    <#if jakartaEEVersion == "None" && microProfileVersion == "5.0">implementation 'javax.ws.rs:javax.ws.rs-api:2.0' </#if>
 }
 
 clean.dependsOn 'libertyStop'

--- a/src/main/resources/templates/maven/pom.xml
+++ b/src/main/resources/templates/maven/pom.xml
@@ -24,13 +24,20 @@
             <scope>provided</scope>
         </dependency>
         </#if>
-         <#if microProfilePomVersion != "None">
+        <#if microProfilePomVersion != "None">
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
             <version>${microProfilePomVersion}</version>
             <type>pom</type>
             <scope>provided</scope>
+        </dependency>
+        </#if>
+        <#if jakartaEEVersion == "None" && microProfilePomVersion == "5.0">
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0</version>
         </dependency>
         </#if>
     </dependencies>


### PR DESCRIPTION
Fix issue #102 

Local testing:

1. Update code, run `mvn liberty:dev`
2. Download `appname.zip` locally for `maven`, ex. https://localhost:9443/api/start?a=app-name&b=maven&e=None&g=com.demo&j=11&m=5.0
3. Download `appname.zip` locally for `gradle`, ex. https://localhost:9443/api/start?a=app-name&b=gradle&e=None&g=com.demo&j=11&m=5.0
4. unzip appname.zip and run `gradlew libertyDev` or `mvnw liberty:dev` to make sure the splash page comes up locally

Once merge into staging, will run cypress tests for starter