### PR TITLE
Fix missing dot slash to execute command in README

### DIFF
--- a/src/main/resources/templates/readme/README.txt
+++ b/src/main/resources/templates/readme/README.txt
@@ -12,12 +12,12 @@ image.
 
 1) Once you download the starter project, unpackage the .zip file on your machine.
 <#if buildType == "maven">
-2) Open a command line session, navigate to the installation directory, and run `mvnw liberty:dev`. 
+2) Open a command line session, navigate to the installation directory, and run `./mvnw liberty:dev`. 
    This will install all required dependencies and start the default server. When complete, you will
    see the necessary features installed and the message "server is ready to run a smarter planet."
 </#if>
 <#if buildType == "gradle">
-2) Open a command line session, navigate to the installation directory, and run `gradlew libertyDev`
+2) Open a command line session, navigate to the installation directory, and run `./gradlew libertyDev`
    to start the default server. When complete, you will see the necessary features installed from 
    the installFeature task and the message "server is ready to run a smarter planet."
 </#if>


### PR DESCRIPTION
Hi!

I believe it's worth putting the dot slash for the developer to just copy and paste.

I hope it helps!