### PR TITLE
Edit the templates to add microprofile-config.properties

### DIFF
--- a/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
+++ b/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
@@ -66,7 +66,7 @@ public class StarterBuilderImpl implements StarterBuilder {
         requestedTemplates.add("server");
         requestedTemplates.add("docker");
         requestedTemplates.add("rest");
-        requestedTemplates.add("readme");
+        requestedTemplates.add("readme");        
     }
 
     @Override
@@ -137,6 +137,10 @@ public class StarterBuilderImpl implements StarterBuilder {
     @Override
     public final StarterBuilder microProfileVersion(String microProfileVersion) {
         this.microProfileVersion = microProfileVersion;
+
+        if(microProfileVersion != "None"){
+            requestedTemplates.add("microprofile");
+        }
 
         if ("4.0".equals(microProfileVersion)) {
             properties.put("microProfilePomVersion", "4.0.1");

--- a/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
+++ b/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
@@ -66,7 +66,7 @@ public class StarterBuilderImpl implements StarterBuilder {
         requestedTemplates.add("server");
         requestedTemplates.add("docker");
         requestedTemplates.add("rest");
-        requestedTemplates.add("readme");        
+        requestedTemplates.add("readme");
     }
 
     @Override
@@ -109,7 +109,7 @@ public class StarterBuilderImpl implements StarterBuilder {
             properties.put("jakartaEEArtifactId", "jakarta.jakartaee-api");
             properties.put("jakartaEEVersion", "8.0.0");
             properties.put("jakartaEEFeature", "jakartaee-8.0");
-        } 
+        }
         else if("9.1".equals(jakartaEEVersion)){
             properties.put("jakartaEEGroupId", "jakarta.platform");
             properties.put("jakartaEEArtifactId", "jakarta.jakartaee-api");
@@ -165,7 +165,7 @@ public class StarterBuilderImpl implements StarterBuilder {
 
     @Override
     public final StarterBuilder buildType(String buildSystem) {
-        String capitalizedBuildType = 
+        String capitalizedBuildType =
             buildSystem.substring(0, 1).toUpperCase() + buildSystem.substring(1);
         properties.put("buildTypeForReadme", capitalizedBuildType); // Used in README.txt
         properties.put("buildType", buildSystem.toLowerCase());

--- a/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
+++ b/src/main/java/io/openliberty/website/starter/impl/StarterBuilderImpl.java
@@ -138,7 +138,7 @@ public class StarterBuilderImpl implements StarterBuilder {
     public final StarterBuilder microProfileVersion(String microProfileVersion) {
         this.microProfileVersion = microProfileVersion;
 
-        if(microProfileVersion != "None"){
+        if(!microProfileVersion.equals("None")){
             requestedTemplates.add("microprofile");
         }
 

--- a/src/main/resources/templates/templates.json
+++ b/src/main/resources/templates/templates.json
@@ -58,7 +58,7 @@
 		{
 			"template": "maven/gitignore",
 			"fileName": ".gitignore"
-		}		
+		}
 	],
 	"docker": [
 		{

--- a/src/main/resources/templates/templates.json
+++ b/src/main/resources/templates/templates.json
@@ -58,7 +58,7 @@
 		{
 			"template": "maven/gitignore",
 			"fileName": ".gitignore"
-		}
+		}		
 	],
 	"docker": [
 		{
@@ -91,6 +91,12 @@
 			"template": "readme/README.txt",
 			"fileName": "README.txt",
 			"process": true
+		}
+	],
+	"microprofile": [
+		{
+			"template": "microprofile/microprofile-config.properties",
+			"fileName": "src/main/resources/META-INF/microprofile-config.properties"
 		}
 	]
 }


### PR DESCRIPTION
Fixes #24
Previously microprofile-config.properties was added in https://github.com/OpenLiberty/start.openliberty.io/pull/91 but not in the templates that are used to generate the starter so this will add them if they choose any MicroProfile version other than "None".