### PR TITLE
278 open liberty 24.0.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ USER 1001
 # Stage 2: Place application on a liberty server
 # TODO: Invest in using a kernel build and use the feature manager to install 
 # needed Liberty features
-FROM icr.io/appcafe/open-liberty:24.0.0.4-kernel-slim-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:24.0.0.6-kernel-slim-java8-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT


### PR DESCRIPTION
For #278 

Upgrade to Open Liberty 24.0.0.6

# Testing
I was able to pull the image onto my laptop to test existence of the container image
```
docker pull icr.io/appcafe/open-liberty:24.0.0.6-kernel-slim-java8-openj9-ubi
24.0.0.6-kernel-slim-java8-openj9-ubi: Pulling from appcafe/open-liberty
076e862febc7: Pull complete
484c852302b0: Pull complete
5d290f9d8518: Pull complete
fcf99e2ba2c6: Pull complete
98b4277d98af: Pull complete
8b824dc5261a: Pull complete
88cc40208de1: Pull complete
d259cbf63b57: Pull complete
3c07ce9a7d33: Pull complete
f100901ed696: Pull complete
a7dddf2c04ab: Pull complete
e15ef6736996: Pull complete
329d6d2e6f7f: Pull complete
c39c14ff21c9: Pull complete
8375936e2dfa: Pull complete
Digest: sha256:3df665c61e034e0b60293f9f19d638050c24d0297512ce418b768ef9fc77c3ee
Status: Downloaded newer image for icr.io/appcafe/open-liberty:24.0.0.6-kernel-slim-java8-openj9-ubi
icr.io/appcafe/open-liberty:24.0.0.6-kernel-slim-java8-openj9-ubi
```