### PR TITLE
Revert "fix: CVE-2024-26308 and CVE-2024-25710"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26</version>
+            <version>1.21</version>
           </dependency>
           <dependency>
             <groupId>org.freemarker</groupId>


### PR DESCRIPTION
Reverts OpenLiberty/start.openliberty.io#296. v1.26 does not exist in the central artifact and it should be 1.26.0 which i can create