### PR TITLE
Upgrade apache commons version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.26.0</version>
           </dependency>
           <dependency>
             <groupId>org.freemarker</groupId>


### PR DESCRIPTION
- upgrade to org.apache.commons to version 1.26 to pickup CVE fixes

Fix https://github.com/OpenLiberty/start.openliberty.io/security/dependabot/2
Fix https://github.com/OpenLiberty/start.openliberty.io/security/dependabot/1
