### PR TITLE
Upgrade to Open Liberty 25.0.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ USER 1001
 # Stage 2: Place application on a liberty server
 # TODO: Invest in using a kernel build and use the feature manager to install 
 # needed Liberty features
-FROM icr.io/appcafe/open-liberty:25.0.0.1-kernel-slim-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:25.0.0.3-kernel-slim-java8-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT


### PR DESCRIPTION
Tested by running the command locally to confirm new image is available 
`docker pull icr.io/appcafe/open-liberty:25.0.0.3-kernel-slim-java8-openj9-ubi` 