### PR TITLE
Update maven and gradle plugin versions (Re-commit)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.11.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/templates/gradle/build.gradle
+++ b/src/main/resources/templates/gradle/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'war'
-    id 'io.openliberty.tools.gradle.Liberty' version '3.9.2'
+    id 'io.openliberty.tools.gradle.Liberty' version '3.9.4'
 }
 
 version '1.0-SNAPSHOT'

--- a/src/main/resources/templates/maven/pom.xml
+++ b/src/main/resources/templates/maven/pom.xml
@@ -52,7 +52,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.11.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Fix issue https://github.com/OpenLiberty/start.openliberty.io/issues/320 updating maven plugin to 3.11.4 and gradle plugin to 3.9.4

Recommitting the PR made by @NottyCode to avoid potential rebase issues. Also updated maven version in `pom.xml` file. It also seemingly was updated in previous commit history.

@yeekangc , let me know if I want to revert that particular commit