### PR TITLE
Revert "Update maven and gradle plugin versions"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.12.0</version>
+                    <version>3.11.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/templates/gradle/build.gradle
+++ b/src/main/resources/templates/gradle/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'war'
-    id 'io.openliberty.tools.gradle.Liberty' version '4.0.0'
+    id 'io.openliberty.tools.gradle.Liberty' version '3.9.5'
 }
 
 version '1.0-SNAPSHOT'

--- a/src/main/resources/templates/maven/pom.xml
+++ b/src/main/resources/templates/maven/pom.xml
@@ -52,7 +52,7 @@
                 <plugin>
                     <groupId>io.openliberty.tools</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>3.12.0</version>
+                    <version>3.11.5</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Reverts OpenLiberty/start.openliberty.io#362
Related to #361 

We cannot move up to Liberty Gradle Plugin (LGP) 4.0.0 at this time. The Open Liberty Starter does not enforce the minimum requirements for LGP 4.0.0. The minimum requirements are Gradle 9 and Java 17.

Additionally, customers may not want to move to Gradle 9 and Java 17 when using LGP. How will the Open Liberty Starter accommodate these users needs to be discussed too.