### PR TITLE
Upgrade to plexus-utils 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.3.0</version>
+            <version>3.6.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Addresses https://github.com/OpenLiberty/start.openliberty.io/security/dependabot/5

3.6.1 was published with the fix
- https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-3.6.1

The dep is only used by the JUnit tests. I ran the JUnit tests locally and they all passed.